### PR TITLE
Stop event propagation on sortable item's dragstart

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -35,13 +35,14 @@ $.fn.sortable = function(options) {
 		}
 		items.attr('draggable', 'true').on('dragstart.h5s', function(e) {
 			if (options.handle && !isHandle) {
-				return;
+				return false;
 			}
 			isHandle = false;
 			var dt = e.originalEvent.dataTransfer;
 			dt.effectAllowed = 'move';
 			dt.setData('Text', 'dummy');
 			index = (dragging = $(this)).addClass('sortable-dragging').index();
+			e.stopPropagation();
 		}).on('dragend.h5s', function() {
 			if (!dragging) {
 				return;


### PR DESCRIPTION
Ignore commit 6d435fc

Stop propogation of dragstart event if caused by a valid handle so as
to not cause possible parent listener to prevent the default drag action.

Example use case:
This enables the ability to rearrange the order of Items and the Subitems within them, although the Subitems within an Item cannot be dragged to other Items.
Item 1
SubItem 1.1
SubItem 1.2
SubItem 1.3
Item 2
SubItem 2.1
SubItem 2.0
Item 3
SubItem 3.1
SubItem 3.2
