### PR TITLE
Trigger 'sortupdate' event when dragging to the same index in another list.

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -22,6 +22,7 @@ $.fn.sortable = function(options) {
 			return;
 		}
 		var isHandle, index, items = $(this).children(options.items);
+		var parent = $(this);
 		var placeholder = $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">');
 		items.find(options.handle).mousedown(function() {
 			isHandle = true;
@@ -48,7 +49,7 @@ $.fn.sortable = function(options) {
 			}
 			dragging.removeClass('sortable-dragging').show();
 			placeholders.detach();
-			if (index != dragging.index()) {
+			if (index != dragging.index() || (!dragging.parent().is(parent))) {
 				dragging.parent().trigger('sortupdate', {item: dragging});
 			}
 			dragging = null;


### PR DESCRIPTION
Right now, 'sortupdate' is triggered only if the index is different. Thus, if I have a list:
- Foo1
- Foo2
- Foo3

And another list:
- Bar1
- Bar2
- Bar3

If I drag Foo2 into the Bar list, such that the lists are now:
- Foo1
- Foo3

and
- Bar1
- Foo2
- Bar2
- Bar3

In this case, 'sortupdate' is not triggered. Dragging to any other location in the Bar list triggers sortupdate. This patch sends sortupdate if the index is the same, but the parent is different.

I am using this plugin mainly for sorting into _unordered_ lists, rather than _reordering_ existent lists, so this was critical for me.
