### PR TITLE
Add oldindex property to sortupdate event data

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -49,7 +49,7 @@ $.fn.sortable = function(options) {
 			dragging.removeClass('sortable-dragging').show();
 			placeholders.detach();
 			if (index != dragging.index()) {
-				dragging.parent().trigger('sortupdate', {item: dragging});
+				dragging.parent().trigger('sortupdate', {item: dragging, oldindex: index});
 			}
 			dragging = null;
 		}).not('a[href], img').on('selectstart.h5s', function() {


### PR DESCRIPTION
knowing the old index is a useful feature for using this in an MVVC application, since the underlying array can be spliced instead of having to be rewritten.

AngularJS example:

``` html
<div data-ng-controller="SortableCTRL">
    <ul id="sortable">
        <li data-ng-repeat="item in sortableArray" data-ng-bind="item"></li>
    </ul>

    <pre data-ng-bind="sortableArray|json"></pre>
</div>
```

``` javascript
function SortableCTRL($scope) {
    $scope.sortableArray = ['One', 'Two', 'Three'];

    $scope.sortupdate = function(e, data) {
        var start = data.oldindex,
            end   = data.item.index();

        $scope.sortableArray.splice(end, 0,
            $scope.sortableArray.splice(start, 1)[0]);

        $scope.$apply();
    };

    setTimeout(function() {//applies this after the items are generated is rendered
        $('#sortable')
            .sortable()
            .on('sortupdate', $scope.sortupdate);
    });
}
```
