### PR TITLE
during ‘destroy’, remove event handlers added with ‘.on('sortupdate', …)’

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -16,6 +16,7 @@ $.fn.sortable = function(options) {
 		if (/^enable|disable|destroy$/.test(method)) {
 			var items = $(this).children($(this).data('items')).attr('draggable', method == 'enable');
 			if (method == 'destroy') {
+				$(this).off('sortupdate');
 				items.add(this).removeData('connectWith items')
 					.off('dragstart.h5s dragend.h5s selectstart.h5s dragover.h5s dragenter.h5s drop.h5s');
 			}


### PR DESCRIPTION
when adding event listeners, i’d expect `.sortable('destroy')` to destroy them.

since jQuery’s recommended way of adding/removing event listeners is with `on`/`off` i did it that way.
