### PR TITLE
Allow for custom placeholders

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -10,7 +10,8 @@ var dragging, placeholders = $();
 $.fn.sortable = function(options) {
 	var method = String(options);
 	options = $.extend({
-		connectWith: false
+		connectWith: false ,
+		placeholder: null
 	}, options);
 	return this.each(function() {
 		if (/^enable|disable|destroy$/.test(method)) {
@@ -22,7 +23,9 @@ $.fn.sortable = function(options) {
 			return;
 		}
 		var isHandle, index, items = $(this).children(options.items);
-		var placeholder = $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">');
+		var placeholder = ( options.placeholder == null )
+				? $('<' + (/^ul|ol$/i.test(this.tagName) ? 'li' : 'div') + ' class="sortable-placeholder">')
+				: $( options.placeholder ).addClass('sortable-placeholder');
 		items.find(options.handle).mousedown(function() {
 			isHandle = true;
 		}).mouseup(function() {


### PR DESCRIPTION
This change was originally authored by @bistoco

This is the safest way to allow users to specify their own custom placeholders, which is required when using tables.

Please merge

------ Original Commit ------

Added option for placeholder
- added custom markup for placeholder as option, useful when using with tables.
  Example :
  // JS CODE
  $('table.data tbody').sortable(
  {  
      items: 'tr' ,
      placeholder : '<tr><td colspan="7">&nbsp;</td></tr>'
  }) ;
  
  // CSS STYLE FOR TR > TD
  .sortable-placeholder td
  {
      background:#FFFEB8;
      height:100px;
      width:100%;
  
  }
