### PR TITLE
Support list items of variable height

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -68,8 +68,16 @@ $.fn.sortable = function(options) {
 			e.preventDefault();
 			e.originalEvent.dataTransfer.dropEffect = 'move';
 			if (items.is(this)) {
+				var draggingHeight = dragging.outerHeight(), thisHeight = $(this).outerHeight();
 				if (options.forcePlaceholderSize) {
-					placeholder.height(dragging.outerHeight());
+					placeholder.height(draggingHeight); 
+				}
+				// Check if $(this) is bigger than the draggable. If it is, we have to define a dead zone to prevent flickering
+				if (thisHeight > draggingHeight){
+				  // Dead zone?
+				  var deadZone = thisHeight - draggingHeight, offsetTop = $(this).offset().top;
+				  if(placeholder.index() < $(this).index() && e.originalEvent.pageY < offsetTop + deadZone) return false;
+				  else if(placeholder.index() > $(this).index() && e.originalEvent.pageY > offsetTop + thisHeight - deadZone) return false;
 				}
 				dragging.hide();
 				$(this)[placeholder.index() < $(this).index() ? 'after' : 'before'](placeholder);


### PR DESCRIPTION
If a list is composed of items of varying height, when dragging a smaller item over a large item, one will see flickering as the placeholder is placed before the item, then after the item, and back again, infinitely.

jQuery-UI uses something approximating a dead zone, where the swap will only occur over an area equal to the item being dragged. For example, if dragging a 20px tall item over a 40px tall item, no swap will occur over the first 20px while dragging from above, or over the last 20px while dragging from below.

This small patch creates a deadzone inside larger items, resolving the flicking issue.
