### PR TITLE
Fix false negative bug when dropping onto same index in new container.

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -42,13 +42,15 @@ $.fn.sortable = function(options) {
 			dt.effectAllowed = 'move';
 			dt.setData('Text', 'dummy');
 			index = (dragging = $(this)).addClass('sortable-dragging').index();
+			start_parent = $(this).parent();
 		}).on('dragend.h5s', function() {
 			if (!dragging) {
 				return;
 			}
 			dragging.removeClass('sortable-dragging').show();
 			placeholders.detach();
-			if (index != dragging.index()) {
+			new_parent = $(this).parent();
+			if (index != dragging.index() || start_parent != new_parent) {
 				dragging.parent().trigger('sortupdate', {item: dragging});
 			}
 			dragging = null;


### PR DESCRIPTION
Resolves following scenario:

Two connected containers, A and B.

When dragging item at index 1 in container A and dropped as index 1 in container B, the sortupdate event is not triggered because the indexes match.

This index match is a false negative in this scenario.
