### PR TITLE
Simplify off call

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -17,7 +17,7 @@ $.fn.sortable = function(options) {
 			var items = $(this).children($(this).data('items')).attr('draggable', method == 'enable');
 			if (method == 'destroy') {
 				items.add(this).removeData('connectWith items')
-					.off('dragstart.h5s dragend.h5s selectstart.h5s dragover.h5s dragenter.h5s drop.h5s');
+					.off('.h5s');
 			}
 			return;
 		}


### PR DESCRIPTION
`.off('.h5s')` will remove handlers from all events marked as `.h5s`
