### PR TITLE
forcePlaceholderSize option: width support added

### DIFF
--- a/jquery.sortable.js
+++ b/jquery.sortable.js
@@ -70,6 +70,7 @@ $.fn.sortable = function(options) {
 			if (items.is(this)) {
 				if (options.forcePlaceholderSize) {
 					placeholder.height(dragging.outerHeight());
+					placeholder.width(dragging.outerWidth());
 				}
 				dragging.hide();
 				$(this)[placeholder.index() < $(this).index() ? 'after' : 'before'](placeholder);


### PR DESCRIPTION
Usage of forcePlaceholderSize now will use width of draggable element for width of placeholder. E.g.: this is useful for dashboards with dynamic widget size.
